### PR TITLE
Remove checksum usage during downloading of baselines/assets. Check size and creation time instead of it

### DIFF
--- a/downloadFiles.bat
+++ b/downloadFiles.bat
@@ -4,4 +4,4 @@ set REMOTE_HOST=%3
 set CUSTOM_KEYS=%~4
 
 bash -c "mkdir -p %LOCAL_DIR%"
-bash -c "rsync -rvzcl %CUSTOM_KEYS% %REMOTE_HOST%:%REMOTE_SOURCE% %LOCAL_DIR%"
+bash -c "rsync -rvztl %CUSTOM_KEYS% %REMOTE_HOST%:%REMOTE_SOURCE% %LOCAL_DIR%"

--- a/downloadFiles.sh
+++ b/downloadFiles.sh
@@ -5,4 +5,4 @@ CUSTOM_KEYS=$4
 
 mkdir -p ${LOCAL_DIR}
 
-rsync -rvzcl ${CUSTOM_KEYS} ${REMOTE_HOST}:${REMOTE_SOURCE} ${LOCAL_DIR}
+rsync -rvztl ${CUSTOM_KEYS} ${REMOTE_HOST}:${REMOTE_SOURCE} ${LOCAL_DIR}

--- a/downloadFilesSync.bat
+++ b/downloadFilesSync.bat
@@ -4,4 +4,4 @@ set REMOTE_HOST=%3
 set CUSTOM_KEYS=%~4
 
 bash -c "mkdir -p %LOCAL_DIR%"
-bash -c "rsync -rvzcl --delete %CUSTOM_KEYS% %REMOTE_HOST%:%REMOTE_SOURCE% %LOCAL_DIR%"
+bash -c "rsync -rvztl --delete %CUSTOM_KEYS% %REMOTE_HOST%:%REMOTE_SOURCE% %LOCAL_DIR%"

--- a/downloadFilesSync.sh
+++ b/downloadFilesSync.sh
@@ -4,4 +4,4 @@ REMOTE_HOST=$3
 CUSTOM_KEYS=$4
 
 mkdir -p ${LOCAL_DIR}
-rsync -rvzcl --delete ${CUSTOM_KEYS} ${REMOTE_HOST}:${REMOTE_SOURCE} ${LOCAL_DIR}
+rsync -rvztl --delete ${CUSTOM_KEYS} ${REMOTE_HOST}:${REMOTE_SOURCE} ${LOCAL_DIR}

--- a/uploadFiles.bat
+++ b/uploadFiles.bat
@@ -5,4 +5,4 @@ set CUSTOM_KEYS=%~4
 
 bash.exe -c "ssh %REMOTE_HOST% 'mkdir -p %REMOTE_PATH%'"
 
-bash.exe -c "rsync -rvzcW %CUSTOM_KEYS% %SOURCE% %REMOTE_HOST%:%REMOTE_PATH%"
+bash.exe -c "rsync -rvztW %CUSTOM_KEYS% %SOURCE% %REMOTE_HOST%:%REMOTE_PATH%"

--- a/uploadFiles.sh
+++ b/uploadFiles.sh
@@ -5,4 +5,4 @@ CUSTOM_KEYS=$4
 
 ssh ${REMOTE_HOST} "mkdir -p ${REMOTE_PATH}"
 
-rsync -rvzcl ${CUSTOM_KEYS} ${SOURCE} ${REMOTE_HOST}:${REMOTE_PATH}
+rsync -rvztl ${CUSTOM_KEYS} ${SOURCE} ${REMOTE_HOST}:${REMOTE_PATH}


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-2142
### Purpose
* Remove checksum usage during downloading of baselines/assets. Check size and creation time instead of it
### :warning: Notes for Reviewers
* Should be applied after release
